### PR TITLE
Align Azure DevOps GoTool version with go.mod

### DIFF
--- a/.azdo/build-pipeline.yml
+++ b/.azdo/build-pipeline.yml
@@ -61,7 +61,7 @@ stages:
           - task: GoTool@0
             displayName: "Install Go"
             inputs:
-              version: 1.22.4
+              version: 1.25.8
           - script: |
               set -e
               mkdir build


### PR DESCRIPTION
## Summary

Align Azure DevOps build pipeline Go version with the module requirement in `go.mod`.

## Changes

- Update `.azdo/build-pipeline.yml`:
  - `GoTool@0` version from `1.22.4` to `1.25.8`

## Why

`go.mod` currently requires Go `1.25.8`, so the Azure DevOps build pipeline should install a matching Go version to avoid toolchain mismatch failures.