### PR TITLE
Add ESRP variable group to Azure DevOps release pipeline

### DIFF
--- a/.azdo/build-pipeline.yml
+++ b/.azdo/build-pipeline.yml
@@ -10,11 +10,12 @@ parameters:
 variables:
   - name: pipelineId
     value: 343
+  - group: AME ESRP Variable Group
 
 stages:
   - stage: build
     pool:
-      name: pool-ubuntu-2004
+      name: pool-ubuntu-2404
     displayName: "Build terraform-provider-modtm"
     jobs:
       - job: build
@@ -128,7 +129,7 @@ stages:
   - stage: github_release
     displayName: "Github Draft Release"
     pool:
-      name: pool-ubuntu-2004
+      name: pool-ubuntu-2404
     jobs:
       - job: release
         displayName: "Github Release"


### PR DESCRIPTION
## Summary

Update the Azure DevOps build/release pipeline to match the working ESRP configuration pattern used by `Azure/tflint-ruleset-avm`.

## Changes

- Add `AME ESRP Variable Group` to `.azdo/build-pipeline.yml`
- Update both Azure DevOps stage pools from `pool-ubuntu-2004` to `pool-ubuntu-2404`

## Why

The release pipeline failed validation because `ConnectedServiceName` referenced `$(ESRPServiceConnectionName)` before that variable was loaded. The referenced working pipeline includes the ESRP variable group that defines the ESRP service connection and related signing variables.